### PR TITLE
Fix dependencies

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,15 +15,15 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 build_flags = -DCORE_DEBUG_LEVEL=5
-lib_deps =  
+lib_deps =
 	prampec/IotWebConf@^3.2.1
 	paulstoffregen/OneWire@^2.3.8
 	milesburton/DallasTemperature@^3.11.0
 	arduino-libraries/NTPClient@^3.2.1
-    prampec/IotWebConf
-    ESP Async WebServer
-    AsyncTCP
-	arduino-libraries/NTPClient
+    prampec/IotWebConf@^3.2.1
+    ESP32Async/ESPAsyncWebServer@^3.7.7
+    ESP32Async/AsyncTCP@^3.4.0
+	arduino-libraries/NTPClient@^3.2.1
 	bblanchon/ArduinoJson@^7.0.4
 upload_protocol = espota
 upload_port = 192.168.0.8


### PR DESCRIPTION
Closes: #17 

This 

```
ESP32Async/ESPAsyncWebServer
ESP32Async/AsyncTCP
```

As the old version is deprecated, see: https://github.com/me-no-dev/ESPAsyncWebServer