### PR TITLE
Fix negative temperature readings stored as huge unsigned values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-08-13
+
+### Fixed
+- Negative temperature readings (below 0 degC) were stored as huge near-`UINT32_MAX` values instead of negative ones. `MeterValue.temperature` was declared `uint32_t` even though sub-zero readings are negative, so assigning a negative `int` wrapped around. Changed the field to `int32_t` throughout the firmware (ring-buffer struct, `MeterValue_write`/`MeterValue_read`, local web UI table). The backend's binary parser also unpacked the `temp` field as unsigned; it now converts it to signed via two's complement. The on-wire byte layout is unchanged, so the backend fix is compatible with firmware already deployed in the field.
+
 ## [1.3.1] - 2026-08-05
 
 ### Added

--- a/backend/index.php
+++ b/backend/index.php
@@ -45,7 +45,7 @@ if (isset($_GET['backend_test']) && $_GET['backend_test'] === "true") {
 $known_fields = [
     'ts'    => 4,   // Unix timestamp (uint32_t)
     'm180'  => 4,   // OBIS 1.8.0 consumption counter (uint32_t, unit: 0.1 Wh)
-    'temp'  => 4,   // temperature * 100 (uint32_t, e.g. 2150 = 21.50 degC)
+    'temp'  => 4,   // temperature * 100 (int32_t, signed, e.g. 2150 = 21.50 degC, -523 = -5.23 degC)
     'solar' => 4,   // PV / MyStrom energy counter (uint32_t)
     'm280'  => 4,   // OBIS 2.8.0 feed-in counter (uint32_t, unit: 0.1 Wh)
 ];
@@ -137,7 +137,18 @@ for ($i = 0; $i < $dataCount; $i++) {
 
     foreach ($active_fields as $field_name => $field_size) {
         // "V" = unsigned 32-bit little-endian, matching uint32_t on the ESP32
-        $parsed[$field_name] = unpack("V", substr($rawData, $o, $field_size))[1];
+        $raw = unpack("V", substr($rawData, $o, $field_size))[1];
+
+        // 'temp' is signed on the firmware (int32_t, negative for sub-zero
+        // readings). PHP has no portable signed-LE unpack code ("l" depends
+        // on machine byte order), so convert manually via two's complement.
+        // This works for firmware sent before and after the int32_t struct
+        // fix, since the wire bytes are identical either way.
+        if ($field_name === 'temp' && $raw >= 0x80000000) {
+            $raw -= 0x100000000;
+        }
+
+        $parsed[$field_name] = $raw;
         $o += $field_size;
     }
 

--- a/src/meter_value.cpp
+++ b/src/meter_value.cpp
@@ -57,7 +57,7 @@ String MeterValue_BuildFieldsParam()
 // Buffer read / write
 // ---------------------------------------------------------------------------
 void MeterValue_write(int index, uint32_t ts, uint32_t m180,
-                      uint32_t temp, uint32_t solar, uint32_t m280)
+                      int32_t temp, uint32_t solar, uint32_t m280)
 {
   if (!MeterValueBuffer) return;
   size_t o = MeterValue_Offset(index);
@@ -69,7 +69,7 @@ void MeterValue_write(int index, uint32_t ts, uint32_t m180,
 }
 
 void MeterValue_read(int index, uint32_t &ts, uint32_t &m180,
-                     uint32_t &temp, uint32_t &solar, uint32_t &m280)
+                     int32_t &temp, uint32_t &solar, uint32_t &m280)
 {
   ts = 0; m180 = 0; temp = 0; solar = 0; m280 = 0;
   if (!MeterValueBuffer) return;
@@ -83,7 +83,8 @@ void MeterValue_read(int index, uint32_t &ts, uint32_t &m180,
 
 bool MeterValue_slot_empty(int index)
 {
-  uint32_t ts, m180, temp, solar, m280;
+  uint32_t ts, m180, solar, m280;
+  int32_t  temp;
   MeterValue_read(index, ts, m180, temp, solar, m280);
   return (ts == 0 && m180 == 0);
 }
@@ -167,7 +168,7 @@ void MeterValue_init_Buffer()
 void resetMeterValue(MeterValue &val)
 {
   int32_t  saved_solar = val.solar;
-  uint32_t saved_temp  = val.temperature;
+  int32_t  saved_temp  = val.temperature;
   val = MeterValue{};
   if (mystrom_PV_object.isChecked()) val.solar = saved_solar;
   val.temperature = saved_temp;

--- a/src/meter_value.h
+++ b/src/meter_value.h
@@ -8,7 +8,7 @@
 struct MeterValue {
   uint32_t timestamp;        // Unix epoch, seconds
   uint32_t meter_value_180;  // OBIS 1.8.0 consumption counter, unit: 0.1 Wh
-  uint32_t temperature;      // temperature * 100 (e.g. 2150 = 21.50 degC)
+  int32_t  temperature;      // temperature * 100, signed (e.g. 2150 = 21.50 degC, -523 = -5.23 degC)
   uint32_t solar;            // MyStrom / solar energy counter
   uint32_t meter_value_280;  // OBIS 2.8.0 feed-in counter, unit: 0.1 Wh
   uint32_t power_import;     // OBIS 1.7.0 import power, unit: W
@@ -49,9 +49,9 @@ static const size_t  BUFFER_REFERENCE_BYTES = 16384;
 size_t MeterValue_EntrySize();
 String MeterValue_BuildFieldsParam();
 void   MeterValue_write(int index, uint32_t ts, uint32_t m180,
-                        uint32_t temp, uint32_t solar, uint32_t m280);
+                        int32_t temp, uint32_t solar, uint32_t m280);
 void   MeterValue_read(int index, uint32_t &ts, uint32_t &m180,
-                       uint32_t &temp, uint32_t &solar, uint32_t &m280);
+                       int32_t &temp, uint32_t &solar, uint32_t &m280);
 bool   MeterValue_slot_empty(int index);
 int    MeterValue_slots_from_budget(size_t budgetBytes);
 int    MeterValue_calc_max_slots_for_display();

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define FIRMWARE_VERSION "1.3.1"
+#define FIRMWARE_VERSION "1.3.2"
 #define CONFIG_VERSION   "2906"

--- a/src/webserver_data.cpp
+++ b/src/webserver_data.cpp
@@ -331,7 +331,8 @@ void Webserver_ShowMeterValues()
   bool first = true;
   for (int m = 0; m < Meter_Value_Buffer_Size; m++)
   {
-    uint32_t ts, m180, temp, solar, m280;
+    uint32_t ts, m180, solar, m280;
+    int32_t  temp;
     MeterValue_read(m, ts, m180, temp, solar, m280);
     if (ts == 0 && m180 == 0) {
       if (first) { first = false; server.sendContent("<tr><td>-----</td></tr>"); }


### PR DESCRIPTION
MeterValue.temperature was uint32_t even though sub-zero readings are negative, so assigning a negative int wrapped around to near UINT32_MAX. Changed the field to int32_t throughout the firmware (ring-buffer struct, MeterValue_write/read, local web UI table) and fixed the backend's binary parser to unpack the temp field as signed instead of unsigned. The on-wire byte layout is unchanged (two's complement), so the backend fix works with already-deployed firmware.